### PR TITLE
Fix image priority and hydration warnings

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,8 +28,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body>
+    // Chakra adds style={{colorScheme: "light"}} data-theme="light" attributes causing
+    // hydration warnings about the client side attributes not matching what was sent from the server.
+    // I don't think there's a better work around as we won't know the color mode preference till it gets client-side.
+    // Similarly class="chakra-ui-light" (or dark) is being added to the body.
+    <html lang="en" suppressHydrationWarning={true}>
+      <body suppressHydrationWarning={true}>
         <Providers>
           <ColorModeScript initialColorMode={theme.config.initialColorMode} />
           <Header />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,7 @@ export default function Home() {
             width="200"
             alt="profile"
             style={profileStyle}
+            priority={true}
           />
           <Text fontSize={["sm", "md", "lg"]}>
             I'm a{" "}


### PR DESCRIPTION
Set the profile image to priority for Lighthouse and added hydration suppression for the color mode change.